### PR TITLE
PR: remove dependency on walkdir and support loading from specified file extensions, falling back on .js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+end_of_line = lf
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+typings

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-test:
-	./node_modules/mocha/bin/_mocha -R spec test --recursive
-
-.PHONY: test

--- a/cnfg.js
+++ b/cnfg.js
@@ -1,26 +1,24 @@
-var
-  pathHelpers = require('path'),
-  resolve = pathHelpers.resolve,
-  _ = require('lodash'),
-  debug = require('debug')('cnfg'),
-  walkDirSync = require('./walkDirSync');
+var pathHelpers = require('path');
+var resolve = pathHelpers.resolve;
+var _ = require('lodash');
+var debug = require('debug')('cnfg');
+var walkDirSync = require('./walkDirSync');
 
 function sanitizeExtensions(configuredExtensions) {
-  if (!configuredExtensions) {
-    return ['.js'];
-  }
-  return Array.isArray(configuredExtensions) 
-          ? configuredExtensions
-          : [configuredExtensions]; 
+	if (!configuredExtensions) {
+		return ['.js'];
+	}
+	return Array.isArray(configuredExtensions) 
+					? configuredExtensions
+					: [configuredExtensions]; 
 }
 
 module.exports = function(path, env, processEnv, configFileExtensions) {
-	var
-    length = path.length,
-	  config = {},
-    depth, files, envs;
+	var length = path.length;
+	var config = {};
+  var depth, files, envs;
 
-  var extensions = sanitizeExtensions(configFileExtensions); 
+	var extensions = sanitizeExtensions(configFileExtensions); 
 
 	env = env || process.env.NODE_ENV || 'development';
 
@@ -29,13 +27,13 @@ module.exports = function(path, env, processEnv, configFileExtensions) {
 	}
 
 	var onlyFiles = function(filepath) {
-    const fileExt = pathHelpers.extname(filepath);
-    if (extensions.indexOf(fileExt) === -1) {
-      return false;
-    }
-    var baseName = pathHelpers.basename(filepath);
-    var baseNameWithoutExtension = baseName.substr(0, baseName.length - fileExt.length);
-    return baseNameWithoutExtension !== 'index';
+		const fileExt = pathHelpers.extname(filepath);
+		if (extensions.indexOf(fileExt) === -1) {
+			return false;
+		}
+		var baseName = pathHelpers.basename(filepath);
+		var baseNameWithoutExtension = baseName.substr(0, baseName.length - fileExt.length);
+		return baseNameWithoutExtension !== 'index';
 	}
 
 	var grouper = function(path) {
@@ -58,7 +56,7 @@ module.exports = function(path, env, processEnv, configFileExtensions) {
 	}
 
 	var endsWith = function(string, suffix) {
-		var l  = string.length - suffix.length;
+		var l	= string.length - suffix.length;
 		return l >= 0 && string.indexOf(suffix, l) === l;
 	}
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "Hierarchical environment configuration for node.js applications",
   "main": "cnfg.js",
   "scripts": {
-    "test": "make test"
+    "prepublish": "test",
+    "test": "run-s test-js test-ts",
+    "test-js": "mocha -R spec test --recursive",
+    "test-ts": "mocha -R spec test-ts/**/*.spec.ts --require ts-node/register --recursive",
+    "autotest-ts": "mocha -R mocha-yar test-ts/**/*.spec.ts --require ts-node/register --recursive --watch --watch-extensions ts",
+    "autotest-js": "mocha -R mocha-yar test --recursive --watch",
+    "autotest": "run-p autotest-js autotest-ts",
+    "postinstall": "typings install"
   },
   "repository": "https://github.com/boo1ean/cnfg.git",
   "author": "Egor Gumenyuk <boo1ean0807@gmail.com>",
@@ -15,8 +22,7 @@
   "homepage": "https://github.com/boo1ean/cnfg",
   "dependencies": {
     "debug": "^2.2.0",
-    "lodash": "^4.6.1",
-    "walkdir": "0.0.7"
+    "lodash": "^4.6.1"
   },
   "keywords": [
     "config",
@@ -30,7 +36,12 @@
     "hierarchical"
   ],
   "devDependencies": {
-    "mocha": "~1.17.0",
-    "chai": "~1.8.1"
+    "chai": "~1.8.1",
+    "mocha": "^3.0.1",
+    "mocha-yar": "^1.0.10",
+    "npm-run-all": "^2.3.0",
+    "ts-node": "^1.2.2",
+    "typescript": "^1.8.10",
+    "typings": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-  "name": "cnfg",
-  "version": "1.1.0",
-  "description": "Hierarchical environment configuration for node.js applications",
-  "main": "cnfg.js",
-  "scripts": {
-    "prepublish": "run-s test",
-    "test": "run-s test-js test-ts",
-    "test-js": "mocha -R spec test --recursive",
-    "test-ts": "mocha -R spec test-ts/**/*.spec.ts --require ts-node/register --recursive",
-    "autotest-ts": "mocha -R mocha-yar test-ts/**/*.spec.ts --require ts-node/register --recursive --watch --watch-extensions ts",
-    "autotest-js": "mocha -R mocha-yar test --recursive --watch",
-    "autotest": "run-p autotest-js autotest-ts",
-    "postinstall": "typings install"
-  },
-  "repository": "https://github.com/boo1ean/cnfg.git",
-  "author": "Egor Gumenyuk <boo1ean0807@gmail.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/boo1ean/cnfg/issues"
-  },
-  "homepage": "https://github.com/boo1ean/cnfg",
-  "dependencies": {
-    "debug": "^2.2.0",
-    "lodash": "^4.6.1"
-  },
-  "keywords": [
-    "config",
-    "settings",
-    "conf",
-    "recursive",
-    "recursively",
-    "environment",
-    "env",
-    "hierarchy",
-    "hierarchical"
-  ],
-  "devDependencies": {
-    "chai": "~1.8.1",
-    "mocha": "^3.0.1",
-    "mocha-yar": "^1.0.10",
-    "npm-run-all": "^2.3.0",
-    "ts-node": "^1.2.2",
-    "typescript": "^1.8.10",
-    "typings": "^1.3.2"
-  }
+	"name": "cnfg",
+	"version": "1.1.0",
+	"description": "Hierarchical environment configuration for node.js applications",
+	"main": "cnfg.js",
+	"scripts": {
+		"prepublish": "run-s test",
+		"test": "run-s test-js test-ts",
+		"test-js": "mocha -R spec test --recursive",
+		"test-ts": "mocha -R spec test-ts/**/*.spec.ts --require ts-node/register --recursive",
+		"autotest-ts": "mocha -R mocha-yar test-ts/**/*.spec.ts --require ts-node/register --recursive --watch --watch-extensions ts",
+		"autotest-js": "mocha -R mocha-yar test --recursive --watch",
+		"autotest": "run-p autotest-js autotest-ts",
+		"postinstall": "typings install"
+	},
+	"repository": "https://github.com/boo1ean/cnfg.git",
+	"author": "Egor Gumenyuk <boo1ean0807@gmail.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/boo1ean/cnfg/issues"
+	},
+	"homepage": "https://github.com/boo1ean/cnfg",
+	"dependencies": {
+		"debug": "^2.2.0",
+		"lodash": "^4.6.1"
+	},
+	"keywords": [
+		"config",
+		"settings",
+		"conf",
+		"recursive",
+		"recursively",
+		"environment",
+		"env",
+		"hierarchy",
+		"hierarchical"
+	],
+	"devDependencies": {
+		"chai": "~1.8.1",
+		"mocha": "^3.0.1",
+		"mocha-yar": "^1.0.10",
+		"npm-run-all": "^2.3.0",
+		"ts-node": "^1.2.2",
+		"typescript": "^1.8.10",
+		"typings": "^1.3.2"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hierarchical environment configuration for node.js applications",
   "main": "cnfg.js",
   "scripts": {
-    "prepublish": "test",
+    "prepublish": "run-s test",
     "test": "run-s test-js test-ts",
     "test-js": "mocha -R spec test --recursive",
     "test-ts": "mocha -R spec test-ts/**/*.spec.ts --require ts-node/register --recursive",

--- a/test-ts/cnfg.spec.ts
+++ b/test-ts/cnfg.spec.ts
@@ -1,0 +1,121 @@
+/// <reference path="../typings/index.d.ts" />
+import { expect } from 'chai';
+const actual_cnfg = require('../cnfg');
+
+describe('cnfg under ts-node', () => {
+  function cnfg(path: string, env?: any, processEnv?: any) {
+    return actual_cnfg(path, env, processEnv, ['.js', '.ts'])
+  }
+  describe('Heirarchical environment config extraction', () => {
+    it('Should extract single-level config very well', () => {
+      // Arrange
+      const
+        path = __dirname + '/config-single-level',
+        expected = {
+          api: { key: '123' },
+          app: { transport: 'http' },
+          db: { name: 'johny' }
+        };
+      // Act
+      const result = cnfg(path, null, null);
+      // Assert
+      expect(result).to.be.deep.equal(expected);
+    })
+    it('Should extract two-level configuration like a boss', function () {
+      var path = __dirname + '/config-two-levels';
+      var expected = {
+        'api': { key: '123' },
+        'app': { transport: 'http' },
+        'db': { name: 'johny' }
+      };
+
+      expect(cnfg(path)).to.be.deep.equal(expected);
+
+      var expected_prod = {
+        'api': { key: 'prod_123' },
+        'app': { transport: 'http' },
+        'db': { name: 'prod_johny', port: 5555 }
+      };
+
+      expect(cnfg(path, 'prod')).to.be.deep.equal(expected_prod);
+
+      var expected_test = {
+        'api': { key: '123', test_secret: 'wow such secret' },
+        'app': { transport: 'http' },
+        'db': { name: 'johny' }
+      };
+
+      expect(cnfg(path, 'test')).to.be.deep.equal(expected_test);
+    });
+
+    it('Should extract configuration with index.ts in base dir', function () {
+      var expected = {
+        'api': { key: '123' },
+        'app': { transport: 'http' },
+        'db': { name: 'johny' }
+      };
+
+      expect(require('./config-with-index')).to.be.deep.equal(expected);
+    });
+
+    it('Should extract two-level configuration with index', function () {
+      var path = './config-two-levels-with-index';
+
+      var expected_prod = {
+        'api': { key: 'prod_123' },
+        'app': { transport: 'http' },
+        'db': { name: 'prod_johny', port: 5555 }
+      };
+
+      expect(require(path)).to.be.deep.equal(expected_prod);
+    });
+
+    it('Should apply overrides env correctly', function () {
+      var path = __dirname + '/config-with-env';
+
+      var expected = {
+        'api': { key: 'prod_123', key2: 'env key', underscored_key: 456 },
+        'app': { transport: 'http' },
+        'db': { name: 'prod_johny', port: 5555 }
+      };
+
+      expect(cnfg(path, 'prod', { CNFG_API__KEY2: 'env key', CNFG_API__UNDERSCORED_KEY: 456 })).to.be.deep.equal(expected);
+    })
+  });
+  describe('Configuration', function () {
+    it('Properties should not be changed', function () {
+      var path = __dirname + '/config-single-level';
+      var expected = {
+        'api': { key: '123' },
+        'app': { transport: 'http' },
+        'db': { name: 'johny' }
+      };
+
+      var config = cnfg(path);
+
+      expect(config).to.be.deep.equal(expected);
+
+      expect(() => {
+        config.api = 1;
+      }).to.throw // running under ts-node, when attempting to assign, this will throw
+      expect(config).to.be.deep.equal(expected);
+    });
+
+    it('May be extended with new properties', function () {
+      var path = __dirname + '/config-single-level';
+      var expected = {
+        'api': { key: '123' },
+        'app': { transport: 'http' },
+        'db': { name: 'johny' }
+      };
+
+      var config = cnfg(path);
+
+      expect(config).to.be.deep.equal(expected);
+
+      config.newProp = 1;
+
+      expect(config).to.have.property('newProp');
+    });
+  });
+});

--- a/test-ts/cnfg.spec.ts
+++ b/test-ts/cnfg.spec.ts
@@ -3,119 +3,119 @@ import { expect } from 'chai';
 const actual_cnfg = require('../cnfg');
 
 describe('cnfg under ts-node', () => {
-  function cnfg(path: string, env?: any, processEnv?: any) {
-    return actual_cnfg(path, env, processEnv, ['.js', '.ts'])
-  }
-  describe('Heirarchical environment config extraction', () => {
-    it('Should extract single-level config very well', () => {
-      // Arrange
-      const
-        path = __dirname + '/config-single-level',
-        expected = {
-          api: { key: '123' },
-          app: { transport: 'http' },
-          db: { name: 'johny' }
-        };
-      // Act
-      const result = cnfg(path, null, null);
-      // Assert
-      expect(result).to.be.deep.equal(expected);
-    })
-    it('Should extract two-level configuration like a boss', function () {
-      var path = __dirname + '/config-two-levels';
-      var expected = {
-        'api': { key: '123' },
-        'app': { transport: 'http' },
-        'db': { name: 'johny' }
-      };
+	function cnfg(path: string, env?: any, processEnv?: any) {
+		return actual_cnfg(path, env, processEnv, ['.js', '.ts'])
+	}
+	describe('Heirarchical environment config extraction', () => {
+		it('Should extract single-level config very well', () => {
+			// Arrange
+			const
+				path = __dirname + '/config-single-level',
+				expected = {
+					api: { key: '123' },
+					app: { transport: 'http' },
+					db: { name: 'johny' }
+				};
+			// Act
+			const result = cnfg(path, null, null);
+			// Assert
+			expect(result).to.be.deep.equal(expected);
+		})
+		it('Should extract two-level configuration like a boss', function () {
+			var path = __dirname + '/config-two-levels';
+			var expected = {
+				'api': { key: '123' },
+				'app': { transport: 'http' },
+				'db': { name: 'johny' }
+			};
 
-      expect(cnfg(path)).to.be.deep.equal(expected);
+			expect(cnfg(path)).to.be.deep.equal(expected);
 
-      var expected_prod = {
-        'api': { key: 'prod_123' },
-        'app': { transport: 'http' },
-        'db': { name: 'prod_johny', port: 5555 }
-      };
+			var expected_prod = {
+				'api': { key: 'prod_123' },
+				'app': { transport: 'http' },
+				'db': { name: 'prod_johny', port: 5555 }
+			};
 
-      expect(cnfg(path, 'prod')).to.be.deep.equal(expected_prod);
+			expect(cnfg(path, 'prod')).to.be.deep.equal(expected_prod);
 
-      var expected_test = {
-        'api': { key: '123', test_secret: 'wow such secret' },
-        'app': { transport: 'http' },
-        'db': { name: 'johny' }
-      };
+			var expected_test = {
+				'api': { key: '123', test_secret: 'wow such secret' },
+				'app': { transport: 'http' },
+				'db': { name: 'johny' }
+			};
 
-      expect(cnfg(path, 'test')).to.be.deep.equal(expected_test);
-    });
+			expect(cnfg(path, 'test')).to.be.deep.equal(expected_test);
+		});
 
-    it('Should extract configuration with index.ts in base dir', function () {
-      var expected = {
-        'api': { key: '123' },
-        'app': { transport: 'http' },
-        'db': { name: 'johny' }
-      };
+		it('Should extract configuration with index.ts in base dir', function () {
+			var expected = {
+				'api': { key: '123' },
+				'app': { transport: 'http' },
+				'db': { name: 'johny' }
+			};
 
-      expect(require('./config-with-index')).to.be.deep.equal(expected);
-    });
+			expect(require('./config-with-index')).to.be.deep.equal(expected);
+		});
 
-    it('Should extract two-level configuration with index', function () {
-      var path = './config-two-levels-with-index';
+		it('Should extract two-level configuration with index', function () {
+			var path = './config-two-levels-with-index';
 
-      var expected_prod = {
-        'api': { key: 'prod_123' },
-        'app': { transport: 'http' },
-        'db': { name: 'prod_johny', port: 5555 }
-      };
+			var expected_prod = {
+				'api': { key: 'prod_123' },
+				'app': { transport: 'http' },
+				'db': { name: 'prod_johny', port: 5555 }
+			};
 
-      expect(require(path)).to.be.deep.equal(expected_prod);
-    });
+			expect(require(path)).to.be.deep.equal(expected_prod);
+		});
 
-    it('Should apply overrides env correctly', function () {
-      var path = __dirname + '/config-with-env';
+		it('Should apply overrides env correctly', function () {
+			var path = __dirname + '/config-with-env';
 
-      var expected = {
-        'api': { key: 'prod_123', key2: 'env key', underscored_key: 456 },
-        'app': { transport: 'http' },
-        'db': { name: 'prod_johny', port: 5555 }
-      };
+			var expected = {
+				'api': { key: 'prod_123', key2: 'env key', underscored_key: 456 },
+				'app': { transport: 'http' },
+				'db': { name: 'prod_johny', port: 5555 }
+			};
 
-      expect(cnfg(path, 'prod', { CNFG_API__KEY2: 'env key', CNFG_API__UNDERSCORED_KEY: 456 })).to.be.deep.equal(expected);
-    })
-  });
-  describe('Configuration', function () {
-    it('Properties should not be changed', function () {
-      var path = __dirname + '/config-single-level';
-      var expected = {
-        'api': { key: '123' },
-        'app': { transport: 'http' },
-        'db': { name: 'johny' }
-      };
+			expect(cnfg(path, 'prod', { CNFG_API__KEY2: 'env key', CNFG_API__UNDERSCORED_KEY: 456 })).to.be.deep.equal(expected);
+		})
+	});
+	describe('Configuration', function () {
+		it('Properties should not be changed', function () {
+			var path = __dirname + '/config-single-level';
+			var expected = {
+				'api': { key: '123' },
+				'app': { transport: 'http' },
+				'db': { name: 'johny' }
+			};
 
-      var config = cnfg(path);
+			var config = cnfg(path);
 
-      expect(config).to.be.deep.equal(expected);
+			expect(config).to.be.deep.equal(expected);
 
-      expect(() => {
-        config.api = 1;
-      }).to.throw // running under ts-node, when attempting to assign, this will throw
-      expect(config).to.be.deep.equal(expected);
-    });
+			expect(() => {
+				config.api = 1;
+			}).to.throw // running under ts-node, when attempting to assign, this will throw
+			expect(config).to.be.deep.equal(expected);
+		});
 
-    it('May be extended with new properties', function () {
-      var path = __dirname + '/config-single-level';
-      var expected = {
-        'api': { key: '123' },
-        'app': { transport: 'http' },
-        'db': { name: 'johny' }
-      };
+		it('May be extended with new properties', function () {
+			var path = __dirname + '/config-single-level';
+			var expected = {
+				'api': { key: '123' },
+				'app': { transport: 'http' },
+				'db': { name: 'johny' }
+			};
 
-      var config = cnfg(path);
+			var config = cnfg(path);
 
-      expect(config).to.be.deep.equal(expected);
+			expect(config).to.be.deep.equal(expected);
 
-      config.newProp = 1;
+			config.newProp = 1;
 
-      expect(config).to.have.property('newProp');
-    });
-  });
+			expect(config).to.have.property('newProp');
+		});
+	});
 });

--- a/test-ts/config-single-level/api.ts
+++ b/test-ts/config-single-level/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+  key: '123'
+}

--- a/test-ts/config-single-level/api.ts
+++ b/test-ts/config-single-level/api.ts
@@ -1,4 +1,4 @@
 /// <reference path="../../typings/index.d.ts" />
 module.exports = {
-  key: '123'
+	key: '123'
 }

--- a/test-ts/config-single-level/app.ts
+++ b/test-ts/config-single-level/app.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	transport: 'http'
+}

--- a/test-ts/config-single-level/db.ts
+++ b/test-ts/config-single-level/db.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	name: 'johny'
+}

--- a/test-ts/config-two-levels-with-index/api.ts
+++ b/test-ts/config-two-levels-with-index/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	key: '123'
+}

--- a/test-ts/config-two-levels-with-index/app.ts
+++ b/test-ts/config-two-levels-with-index/app.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	transport: 'http'
+}

--- a/test-ts/config-two-levels-with-index/db.ts
+++ b/test-ts/config-two-levels-with-index/db.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	name: 'johny'
+}

--- a/test-ts/config-two-levels-with-index/index.ts
+++ b/test-ts/config-two-levels-with-index/index.ts
@@ -1,0 +1,2 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = require('../../')(__dirname, 'prod', null, ['.js', '.ts']);

--- a/test-ts/config-two-levels-with-index/prod/api.ts
+++ b/test-ts/config-two-levels-with-index/prod/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	key: 'prod_123'
+}

--- a/test-ts/config-two-levels-with-index/prod/db.ts
+++ b/test-ts/config-two-levels-with-index/prod/db.ts
@@ -1,0 +1,5 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	name: 'prod_johny',
+	port: 5555
+}

--- a/test-ts/config-two-levels/api.ts
+++ b/test-ts/config-two-levels/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	key: '123'
+}

--- a/test-ts/config-two-levels/app.ts
+++ b/test-ts/config-two-levels/app.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	transport: 'http'
+}

--- a/test-ts/config-two-levels/db.ts
+++ b/test-ts/config-two-levels/db.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	name: 'johny'
+}

--- a/test-ts/config-two-levels/prod/api.ts
+++ b/test-ts/config-two-levels/prod/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	key: 'prod_123'
+}

--- a/test-ts/config-two-levels/prod/db.ts
+++ b/test-ts/config-two-levels/prod/db.ts
@@ -1,0 +1,5 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	name: 'prod_johny',
+	port: 5555
+}

--- a/test-ts/config-two-levels/test/api.ts
+++ b/test-ts/config-two-levels/test/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	test_secret: 'wow such secret'
+}

--- a/test-ts/config-with-env/api.ts
+++ b/test-ts/config-with-env/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	key: '123'
+}

--- a/test-ts/config-with-env/app.ts
+++ b/test-ts/config-with-env/app.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	transport: 'http'
+}

--- a/test-ts/config-with-env/db.ts
+++ b/test-ts/config-with-env/db.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	name: 'johny'
+}

--- a/test-ts/config-with-env/prod/api.ts
+++ b/test-ts/config-with-env/prod/api.ts
@@ -1,0 +1,5 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	key: 'prod_123',
+	underscored_key: 123
+}

--- a/test-ts/config-with-env/prod/db.ts
+++ b/test-ts/config-with-env/prod/db.ts
@@ -1,0 +1,5 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	name: 'prod_johny',
+	port: 5555
+}

--- a/test-ts/config-with-env/test/api.js
+++ b/test-ts/config-with-env/test/api.js
@@ -1,0 +1,4 @@
+/// <reference path="../../../typings/index.d.ts" />
+module.exports = {
+	test_secret: 'wow such secret'
+}

--- a/test-ts/config-with-index/api.ts
+++ b/test-ts/config-with-index/api.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	key: '123'
+}

--- a/test-ts/config-with-index/app.ts
+++ b/test-ts/config-with-index/app.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	transport: 'http'
+}

--- a/test-ts/config-with-index/db.ts
+++ b/test-ts/config-with-index/db.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = {
+	name: 'johny'
+}

--- a/test-ts/config-with-index/index.ts
+++ b/test-ts/config-with-index/index.ts
@@ -1,0 +1,2 @@
+/// <reference path="../../typings/index.d.ts" />
+module.exports = require('../../')(__dirname, null, null, ['.js', '.ts']);

--- a/test/cnfg.js
+++ b/test/cnfg.js
@@ -1,5 +1,5 @@
-var cnfg = require('../'),
-    expect = require('chai').expect;
+var cnfg = require('../');
+var expect = require('chai').expect;
 
 describe('Hierarchical environment config extraction', function() {
 	it('Should extract single-level config very well', function() {

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,9 @@
 {
-  "name": "cnfg-ng",
-  "dependencies": {},
-  "globalDevDependencies": {
-    "chai": "registry:dt/chai#3.4.0+20160601211834",
-    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
-    "node": "registry:dt/node#6.0.0+20160805072842"
-  }
+	"name": "cnfg-ng",
+	"dependencies": {},
+	"globalDevDependencies": {
+		"chai": "registry:dt/chai#3.4.0+20160601211834",
+		"mocha": "registry:dt/mocha#2.2.5+20160720003353",
+		"node": "registry:dt/node#6.0.0+20160805072842"
+	}
 }

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,9 @@
+{
+  "name": "cnfg-ng",
+  "dependencies": {},
+  "globalDevDependencies": {
+    "chai": "registry:dt/chai#3.4.0+20160601211834",
+    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
+    "node": "registry:dt/node#6.0.0+20160805072842"
+  }
+}

--- a/walkDirSync.js
+++ b/walkDirSync.js
@@ -1,35 +1,34 @@
-var
-  pathHelpers = require('path'),
-  debug = require('debug')('cnfg'),
-  fs = require('fs');
+var	pathHelpers = require('path');
+var debug = require('debug')('cnfg');
+var fs = require('fs');
 
 function isDirectory(path) {
-  try {
-    var info = fs.lstatSync(path);
-    return info.isDirectory();
-  } catch (ignore) {
-    return false;
-  }
+	try {
+		var info = fs.lstatSync(path);
+		return info.isDirectory();
+	} catch (ignore) {
+		return false;
+	}
 }
 
 module.exports = function walkDirSync(path) {
-  try {
-    debug('read contents of dir: ', path);
-    var
-      contents = fs.readdirSync(path),
-      result = []
-    contents.forEach(function (item) {
-      var fullPath = pathHelpers.join(path, item);
-      if (isDirectory(fullPath)) {
-        var subContents = walkDirSync(fullPath);
-        result.push.apply(result, subContents);
-      } else {
-        result.push(fullPath);
-      }
-    })
-    debug('found ', result.length, ' items under ', path);
-    return result;
-  } catch (ignore) {
-    return []
-  }
+	try {
+		debug('read contents of dir: ', path);
+		var
+			contents = fs.readdirSync(path),
+			result = []
+		contents.forEach(function (item) {
+			var fullPath = pathHelpers.join(path, item);
+			if (isDirectory(fullPath)) {
+				var subContents = walkDirSync(fullPath);
+				result.push.apply(result, subContents);
+			} else {
+				result.push(fullPath);
+			}
+		})
+		debug('found ', result.length, ' items under ', path);
+		return result;
+	} catch (ignore) {
+		return []
+	}
 }

--- a/walkDirSync.js
+++ b/walkDirSync.js
@@ -1,0 +1,35 @@
+var
+  pathHelpers = require('path'),
+  debug = require('debug')('cnfg'),
+  fs = require('fs');
+
+function isDirectory(path) {
+  try {
+    var info = fs.lstatSync(path);
+    return info.isDirectory();
+  } catch (ignore) {
+    return false;
+  }
+}
+
+module.exports = function walkDirSync(path) {
+  try {
+    debug('read contents of dir: ', path);
+    var
+      contents = fs.readdirSync(path),
+      result = []
+    contents.forEach(function (item) {
+      var fullPath = pathHelpers.join(path, item);
+      if (isDirectory(fullPath)) {
+        var subContents = walkDirSync(fullPath);
+        result.push.apply(result, subContents);
+      } else {
+        result.push(fullPath);
+      }
+    })
+    debug('found ', result.length, ' items under ', path);
+    return result;
+  } catch (ignore) {
+    return []
+  }
+}


### PR DESCRIPTION
Hi

We have been doing some work in Typescript with a client. They introduced cnfg as the mechanism for building and applying configuration based on small modules and using the CNFG_\* environment overrides. Unfortunately, we found that we often had loading issues under Windows -- sometimes configuration would just "not be there" according to cnfg, though the files were on disk.

The problem was tracked down to the dependent package walkdir, which uses filesystem inode identifiers as a key when keeping a lookup of files whilst traversing the filesystem. It turns out that some filesystems (of which NTFS is a prime example), may not guarantee unique inode identifiers when getting results from node's fs.lstat() and fs.lstatSync() functions. I've replicated the issue myself, but this is a long-standing problem that I've found scattered across the web, with a really old example here: [https://github.com/mhevery/jasmine-node/issues/378](https://github.com/mhevery/jasmine-node/issues/378)

Probably a good thing to do would be to PR against walkdir too with a fix for the issue. However, another useful change would be to allow loading from files other than just .js files -- for example when running under an on-the-fly transpiler like ts-node. This is also included, at minimal cost.

Please review the commit message for more information. 

I had worked around the load issue with a very minimal file loader which did much the same as cnfg, but it turns out our client also relies on the CNFG_\* variables. Rather than re-implement that functionality too, I decided to fork and provide a PR, if you're interested. However, I need to release to npmjs.com so I can use in production code today. If you accept the PR, I'll gladly switch back to your package and request npmjs.com to take down mine, which I'm (unimaginatively) calling cnfg-ng (next-gen, since I can't put ++ in the package name)
